### PR TITLE
Update to allow using previous bounds with categories.

### DIFF
--- a/lipo/optimizer.py
+++ b/lipo/optimizer.py
@@ -108,6 +108,9 @@ class GlobalOptimizer:
         self.lower_bounds = lower_bounds
         self.upper_bounds = upper_bounds
         for name, cats in self.categories.items():
+            # we dont need to check both, lower and upper bounds
+            if name in lower_bounds:
+                continue
             self.lower_bounds[name] = 0
             self.upper_bounds[name] = len(cats) - 1
 


### PR DESCRIPTION
With this update we can use bounds from previous runs with categories.  This allows, for example, to reduce the iteration space when using categories. For this it's necessary to have somehow saved the bounds resulting form previous runs of the optimizer.